### PR TITLE
No.12 商品一覧画面、範囲検索の修正

### DIFF
--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -95,11 +95,19 @@ public class ProductService {
 		// weight で範囲検索
 		if (form.getWeight1() != null && form.getWeight2() != null) {
 			query.where(builder.between(root.get("weight"), form.getWeight1(), form.getWeight2()));
+		}else if (form.getWeight1() != null) {
+			query.where(builder.greaterThanOrEqualTo(root.get("weight"), form.getWeight1()));
+		} else if (form.getWeight2() != null) {
+			query.where(builder.lessThanOrEqualTo(root.get("weight"), form.getWeight2()));
 		}
 
 		// height で範囲検索
 		if (form.getHeight1() != null && form.getHeight2() != null) {
 			query.where(builder.between(root.get("height"), form.getHeight1(), form.getHeight2()));
+		}else if (form.getHeight1() != null) {
+			query.where(builder.greaterThanOrEqualTo(root.get("height"), form.getHeight1()));
+		} else if (form.getHeight2() != null) {
+			query.where(builder.lessThanOrEqualTo(root.get("height"), form.getHeight2()));
 		}
 
 		// price で範囲検索


### PR DESCRIPTION
重さと高さの範囲検索において、片方だけ入力して検索を行うと正常に検索がかからないため、最大値または最小値のみ入れても正常に検索が行えるようにしました。