### PR TITLE
No.15 取引先会社名を必須項目に修正

### DIFF
--- a/src/main/resources/templates/company/form.html
+++ b/src/main/resources/templates/company/form.html
@@ -10,7 +10,7 @@
 
     <div class="form-group">
       <label for="name">取引先会社名</label>
-      <input id="name" name="name" type="text" class="form-control" th:field="*{name}" />
+      <input id="name" name="name" type="text" class="form-control" th:field="*{name}" required/>
     </div>
     <div class="form-group">
       <label for="email">Email</label>


### PR DESCRIPTION
新規登録で取引先会社名を必須項目に修正。
取引先会社名を空のまま登録しようとすると、エラー表示され、画面を移行しないよう修正。