### PR TITLE
No.19 キャンペーンコード項目を必須項目に修正

### DIFF
--- a/src/main/java/com/example/model/Campaign.java
+++ b/src/main/java/com/example/model/Campaign.java
@@ -41,6 +41,7 @@ public class Campaign extends TimeEntity implements Serializable {
 	private String name;
 
 	@Column(name = "code", nullable = false)
+	@NotEmpty(message = "キャンペーンコードを入力してください。")
 	private String code;
 
 	@Column(name = "from_date", nullable = false)


### PR DESCRIPTION
新規登録時、及び、編集登録時、コードを空のまま入力するとエラーが発生するように修正しました。（必須項目にしました。）