### PR TITLE
No.21 ステータス一括更新エラー時の処理。

### DIFF
--- a/src/main/java/com/example/service/CampaignService.java
+++ b/src/main/java/com/example/service/CampaignService.java
@@ -117,11 +117,11 @@ public class CampaignService {
 	 * @param nexStatus 更新後ステータス
 	 * @throws Exception
 	 */
-	@Transactional(readOnly = false, rollbackFor = RuntimeException.class)
+	@Transactional(readOnly = false, rollbackFor = Exception.class)
 	public void bulkStatusUpdate(List<Long> idList, CampaignStatus nexStatus) throws Exception {
 		try {
 			idList.forEach(id -> {
-				Campaign campaign = campaignRepository.findById(id).get();
+				Campaign campaign = campaignRepository.findById(id).orElseThrow(() -> new RuntimeException("Campaign not found for id: " + id));
 				// 更新前後のステータスが同じ場合はエラー
 				if (nexStatus.getId() == campaign.getStatus().getId()) {
 					throw new RuntimeException(campaign.getName() + "にステータスの変更がないため、ステータスの一括更新に失敗しました。");

--- a/src/main/java/com/example/service/CampaignService.java
+++ b/src/main/java/com/example/service/CampaignService.java
@@ -75,8 +75,8 @@ public class CampaignService {
 			while ((line = br.readLine()) != null) {
 				final String[] split = line.replace("\"", "").split(",");
 				campaigns.add(new Campaign(split[0], split[1], split[2], split[3],
-											DiscountType.valueOf(Integer.parseInt(split[4])),
-											CampaignStatus.valueOf(Integer.parseInt(split[5])), split[6]));
+						DiscountType.valueOf(Integer.parseInt(split[4])),
+						CampaignStatus.valueOf(Integer.parseInt(split[5])), split[6]));
 			}
 			batchInsert(campaigns);
 
@@ -121,7 +121,7 @@ public class CampaignService {
 	public void bulkStatusUpdate(List<Long> idList, CampaignStatus nexStatus) throws Exception {
 		try {
 			idList.forEach(id -> {
-				Campaign campaign = campaignRepository.findById(id).orElseThrow(() -> new RuntimeException("Campaign not found for id: " + id));
+				Campaign campaign = campaignRepository.findById(id).get();
 				// 更新前後のステータスが同じ場合はエラー
 				if (nexStatus.getId() == campaign.getStatus().getId()) {
 					throw new RuntimeException(campaign.getName() + "にステータスの変更がないため、ステータスの一括更新に失敗しました。");


### PR DESCRIPTION
ステータス一括更新時、ステータスの変更がないデータがある場合、ロールバックするように修正。