### PR TITLE
No.24 大文字小文字の区別をしない検索に修正

### DIFF
--- a/src/main/java/com/example/service/ProductService.java
+++ b/src/main/java/com/example/service/ProductService.java
@@ -81,12 +81,12 @@ public class ProductService {
 		// formの値を元に検索条件を設定する
 		if (!StringUtils.isEmpty(form.getName())) {
 			// name で部分一致検索
-			query.where(builder.like(root.get("name"), "%" + form.getName() + "%"));
+			query.where(builder.like(builder.lower(root.get("name")), "%" + form.getName().toLowerCase() + "%"));
 		}
 
 		if (!StringUtils.isEmpty(form.getCode())) {
 			// code で部分一致検索
-			query.where(builder.like(root.get("code"), "%" + form.getCode() + "%"));
+			query.where(builder.like(builder.lower(root.get("code")), "%" + form.getCode().toLowerCase() + "%"));
 		}
 
 		if (form.getCategories() != null && form.getCategories().size() > 0) {

--- a/src/test/java/com/example/controller/OrderControllerTests.java
+++ b/src/test/java/com/example/controller/OrderControllerTests.java
@@ -123,7 +123,7 @@ public class OrderControllerTests {
 		product.setCode("42");
 		product.setWeight(42);
 		product.setHeight(42);
-		product.setPrice(42);
+		product.setPrice(42.0);
 		product.setTaxType(1);
 		productService.save(product);
 		mvc.perform(

--- a/src/test/java/com/example/controller/ShopProductControllerTests.java
+++ b/src/test/java/com/example/controller/ShopProductControllerTests.java
@@ -77,7 +77,7 @@ public class ShopProductControllerTests {
 		product.setCode("42");
 		product.setWeight(42);
 		product.setHeight(42);
-		product.setPrice(42);
+		product.setPrice(42.0);
 		product.setTaxType(1);
 		productService.save(product);
 		mvc.perform(MockMvcRequestBuilders.get("/shops/" + shop.getId() + "/products/" + product.getId()))
@@ -177,7 +177,7 @@ public class ShopProductControllerTests {
 		product.setCode("42");
 		product.setWeight(42);
 		product.setHeight(42);
-		product.setPrice(42);
+		product.setPrice(42.0);
 		product.setTaxType(1);
 		productService.save(product);
 
@@ -224,7 +224,7 @@ public class ShopProductControllerTests {
 		product.setCode("42");
 		product.setWeight(42);
 		product.setHeight(42);
-		product.setPrice(42);
+		product.setPrice(42.0);
 		product.setTaxType(1);
 		productService.save(product);
 
@@ -281,7 +281,7 @@ public class ShopProductControllerTests {
 		product.setCode("42");
 		product.setWeight(42);
 		product.setHeight(42);
-		product.setPrice(42);
+		product.setPrice(42.0);
 		product.setTaxType(1);
 		productService.save(product);
 


### PR DESCRIPTION
商品一覧表示画面で名前とコードの検索において、大文字小文字の区別をしないように修正。