### PR TITLE
No.25 商品一覧の重複表示修正

### DIFF
--- a/src/main/java/com/example/entity/ProductWithCategoryName.java
+++ b/src/main/java/com/example/entity/ProductWithCategoryName.java
@@ -1,5 +1,7 @@
 package com.example.entity;
 
+import java.util.List;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -21,9 +23,9 @@ public class ProductWithCategoryName {
 
 	private Double price;
 
-	private String categoryName;
+	private List<String> categoryName;
 
-	public ProductWithCategoryName(Long id, String code, String name, Integer weight, Integer height, Double price, String categoryName) {
+	public ProductWithCategoryName(Long id, String code, String name, Integer weight, Integer height, Double price, List<String> categoryName) {
 		this.setId(id);
 		this.setCode(code);
 		this.setName(name);

--- a/src/main/resources/templates/shop_product/index.html
+++ b/src/main/resources/templates/shop_product/index.html
@@ -76,7 +76,9 @@
         <td th:text="${product.name}"></td>
         <td th:text="${product.code}"></td>
         <td>
-          <span class="badge text-bg-info" th:text="${product.categoryName}"></span>
+          <span  th:each="category : ${product.categoryName}">
+            <span class="badge text-bg-info" th:text="${category}"></span>
+          </span>
         </td>
         <td th:text="${product.weight}"></td>
         <td th:text="${product.height}"></td>


### PR DESCRIPTION
商品一覧で複数カテゴリが紐づけされているとき、カテゴリごとに商品データを表示する（重複表示する）のではなく、1レコードに表示するように修正。